### PR TITLE
Add NSS harness.

### DIFF
--- a/harness/nss/README.md
+++ b/harness/nss/README.md
@@ -1,0 +1,26 @@
+NSS test harness for testing ML-KEM
+
+
+Compile with:
+```
+gcc  -I/usr/include/nss3 -I/usr/include/nspr4 -o time_decapsulate time_decapsulate.c readpem.c -lnss3 -lnssutil3 -lplds4 -lplc4 -lnspr4 -lpthread -ldl 
+```
+
+Generate test vectors as in main readme
+
+Run with:
+```
+taskset --cpu-list 4 ./harness/nss/time_decapsulate -i test-dir/ciphers.bin -o test-dir/raw_times.bin -k ml-kem-768-dk.pem -n 1088
+```
+
+Extract the data:
+```
+PYTHONPATH=../tlsfuzzer ../tlsfuzzer/venv-py3-opt-deps/bin/python3 ../tlsfuzzer/tlsfuzzer/extract.py -o test-dir -l test-dir/log.csv --raw-time test-dir/raw_times.bin --binary 8 --clock-frequency 3417.600
+```
+
+or:
+```
+PYTHONPATH=../tlsfuzzer:../kyber-py/src/ ../tlsfuzzer/venv-py3-opt-deps/bin/python extract.py -o test-dir --ml-kem-keys ml-kem-768-dk.pem --raw-values test-dir/ciphers.bin -l test-dir/log.csv --raw-time test-dir/raw_times.csv --binary 8 --clock-frequency 3417.600
+```
+
+Continue analysis as in main readme

--- a/harness/nss/readpem.c
+++ b/harness/nss/readpem.c
@@ -1,0 +1,505 @@
+/* 
+ * NSS does not handle external ML-KEM keys yet.
+ * replicate the NSS raw key structure so we can parse
+ * PEM key. In the future, we can use the NSS builtin
+ * functions to import a key from raw pem data. For now
+ * this function only handles ml-kem keys */
+#include <seccomon.h>
+#include <pk11pub.h>
+#include <keythi.h>
+#include <keyhi.h>
+#include <nssb64.h>
+
+struct seckeyKyberPrivateKeyStr {
+    KyberParams params;
+    SECItem privateValue;
+    SECItem seed;
+};
+typedef struct seckeyKyberPrivateKeyStr seckeyKyberPrivateKey;
+
+/*
+** raw private key object
+*/
+struct seckeyRawPrivateKeyStr {
+    PLArenaPool *arena;
+    KeyType keyType;
+    union {
+        seckeyKyberPrivateKey kyber;
+    } u;
+};
+typedef struct seckeyRawPrivateKeyStr seckeyRawPrivateKey;
+
+SEC_ASN1_MKSUB(SEC_OctetStringTemplate)
+
+/* ASN1 Templates for new decoder/encoder */
+/*
+ * Attribute value for PKCS8 entries (static?)
+ */
+const SEC_ASN1Template seckey_AttributeTemplate[] = {
+    { SEC_ASN1_SEQUENCE,
+      0, NULL, sizeof(SECKEYAttribute) },
+    { SEC_ASN1_OBJECT_ID, offsetof(SECKEYAttribute, attrType) },
+    { SEC_ASN1_SET_OF | SEC_ASN1_XTRN, offsetof(SECKEYAttribute, attrValue),
+      SEC_ASN1_SUB(SEC_AnyTemplate) },
+    { 0 }
+};
+
+const SEC_ASN1Template seckey_SetOfAttributeTemplate[] = {
+    { SEC_ASN1_SET_OF, 0, seckey_AttributeTemplate },
+};
+
+const SEC_ASN1Template seckey_PrivateKeyInfoTemplate[] = {
+    { SEC_ASN1_SEQUENCE, 0, NULL, sizeof(SECKEYPrivateKeyInfo) },
+    { SEC_ASN1_INTEGER, offsetof(SECKEYPrivateKeyInfo, version) },
+    { SEC_ASN1_INLINE | SEC_ASN1_XTRN,
+      offsetof(SECKEYPrivateKeyInfo, algorithm),
+      SEC_ASN1_SUB(SECOID_AlgorithmIDTemplate) },
+    { SEC_ASN1_OCTET_STRING, offsetof(SECKEYPrivateKeyInfo, privateKey) },
+    { SEC_ASN1_OPTIONAL | SEC_ASN1_CONSTRUCTED | SEC_ASN1_CONTEXT_SPECIFIC | 0,
+      offsetof(SECKEYPrivateKeyInfo, attributes),
+      seckey_SetOfAttributeTemplate },
+    { 0 }
+};
+
+const SEC_ASN1Template seckey_PointerToPrivateKeyInfoTemplate[] = {
+    { SEC_ASN1_POINTER, 0, seckey_PrivateKeyInfoTemplate }
+};
+
+const SEC_ASN1Template seckey_MLKEMPrivateKeyBothExportTemplate[] = {
+    { SEC_ASN1_CHOICE, 0, NULL, sizeof(seckeyRawPrivateKey) },
+    { SEC_ASN1_SEQUENCE, 0, NULL, sizeof(seckeyRawPrivateKey) },
+    { SEC_ASN1_OCTET_STRING, offsetof(seckeyRawPrivateKey, u.kyber.seed) },
+    { SEC_ASN1_OCTET_STRING, offsetof(seckeyRawPrivateKey, u.kyber.privateValue) },
+    { 0 }
+};
+
+const SEC_ASN1Template seckey_MLKEMPrivateKeySeedExportTemplate[] = {
+    { SEC_ASN1_CHOICE, 0, NULL, sizeof(seckeyRawPrivateKey) },
+    { SEC_ASN1_CONTEXT_SPECIFIC | 0,
+      offsetof(seckeyRawPrivateKey, u.kyber.seed),
+      SEC_ASN1_SUB(SEC_OctetStringTemplate) },
+    { 0 }
+};
+
+const SEC_ASN1Template seckey_MLKEMPrivateKeyKeyExportTemplate[] = {
+    { SEC_ASN1_CHOICE, 0, NULL, sizeof(seckeyRawPrivateKey) },
+    { SEC_ASN1_OCTET_STRING, offsetof(seckeyRawPrivateKey, u.kyber.privateValue) },
+    { 0 }
+};
+
+
+#define USGOV 0x60, 0x86, 0x48, 0x01, 0x65
+#define NISTALGS USGOV, 3, 4
+#define KEMS NISTALGS, 4
+
+unsigned char oid_value_ml_kem_768[] = { KEMS, 2 };
+unsigned char oid_value_ml_kem_1024[] = { KEMS, 3 };
+
+SECItem oid_item_ml_kem_768 = { siBuffer, oid_value_ml_kem_768,
+                                sizeof(oid_value_ml_kem_768) };
+SECItem oid_item_ml_kem_1024 = { siBuffer, oid_value_ml_kem_1024,
+                                sizeof(oid_value_ml_kem_1024) };
+
+SECOidData oid_data_ml_kem_768 = {
+    { siBuffer, oid_value_ml_kem_768, sizeof(oid_value_ml_kem_768) },
+    SEC_OID_UNKNOWN, "ML-KEM-768", CKM_ML_KEM, INVALID_CERT_EXTENSION,
+};
+
+SECOidData oid_data_ml_kem_1024 = {
+    { siBuffer, oid_value_ml_kem_1024, sizeof(oid_value_ml_kem_1024) },
+    SEC_OID_UNKNOWN, "ML-KEM-1024", CKM_ML_KEM, INVALID_CERT_EXTENSION,
+};
+
+CK_ML_KEM_PARAMETER_SET_TYPE
+get_MLKEMParamSet(KyberParams params)
+{
+    switch (params) {
+    case params_ml_kem768:
+    case params_ml_kem768_test_mode:
+        return CKP_ML_KEM_768;
+    case params_ml_kem1024:
+    case params_ml_kem1024_test_mode:
+        return CKP_ML_KEM_1024;
+    default:
+        break;
+    }
+    return (CK_ULONG)-1UL;
+}
+
+KyberParams
+KyberParamsAlgTag(SECOidTag algTag)
+{
+    SECOidTag oid_ml_kem_768 = SEC_OID_UNKNOWN;
+    SECOidTag oid_ml_kem_1024 = SEC_OID_UNKNOWN;
+
+    oid_ml_kem_768 = SECOID_AddEntry(&oid_data_ml_kem_768);
+    oid_ml_kem_1024 = SECOID_AddEntry(&oid_data_ml_kem_1024);
+    if (oid_ml_kem_768 == algTag) {
+        return params_ml_kem768;
+    }
+    if (oid_ml_kem_1024 == algTag) {
+        return params_ml_kem1024;
+    }
+    return params_kyber_invalid;
+}
+
+SECKEYPrivateKey *
+pk11_MakePrivKey(PK11SlotInfo *slot, KeyType keyType,
+                 PRBool isTemp, CK_OBJECT_HANDLE privID, void *wincx)
+{
+    PLArenaPool *arena;
+    SECKEYPrivateKey *privKey;
+    PRBool isPrivate;
+    SECStatus rv;
+
+    /* now we need to create space for the private key */
+    arena = PORT_NewArena(DER_DEFAULT_CHUNKSIZE);
+    if (arena == NULL)
+        return NULL;
+
+    privKey = (SECKEYPrivateKey *)
+        PORT_ArenaZAlloc(arena, sizeof(SECKEYPrivateKey));
+    if (privKey == NULL) {
+        PORT_FreeArena(arena, PR_FALSE);
+        return NULL;
+    }
+
+    privKey->arena = arena;
+    privKey->keyType = keyType;
+    privKey->pkcs11Slot = PK11_ReferenceSlot(slot);
+    privKey->pkcs11ID = privID;
+    privKey->pkcs11IsTemp = isTemp;
+    privKey->wincx = wincx;
+
+    return privKey;
+}
+
+#define PK11_SETATTRS(x, id, v, l) \
+    (x)->type = (id);              \
+    (x)->pValue = (v);             \
+    (x)->ulValueLen = (l);
+
+SECStatus
+pk11_ImportAndReturnPrivateKey(PK11SlotInfo *slot, seckeyRawPrivateKey *lpk,
+                               SECItem *nickname, PRBool isPrivate,
+                               unsigned int keyUsage,
+                               SECKEYPrivateKey **privk,
+                               void *wincx)
+{
+    CK_BBOOL cktrue = CK_TRUE;
+    CK_BBOOL ckfalse = CK_FALSE;
+    CK_OBJECT_CLASS keyClass = CKO_PRIVATE_KEY;
+    CK_KEY_TYPE keyType = CKK_RSA;
+    CK_OBJECT_HANDLE objectID;
+    CK_ATTRIBUTE theTemplate[20];
+    int templateCount = 0;
+    SECStatus rv = SECFailure;
+    CK_ATTRIBUTE *attrs;
+    CK_ATTRIBUTE *signedattr = NULL;
+    int signedcount = 0;
+    CK_ATTRIBUTE *ap;
+    SECItem *ck_id = NULL;
+    CK_ULONG paramSet;
+    PK11GenericObject *genObj = NULL;
+
+    attrs = theTemplate;
+
+    PK11_SETATTRS(attrs, CKA_CLASS, &keyClass, sizeof(keyClass));
+    attrs++;
+    PK11_SETATTRS(attrs, CKA_KEY_TYPE, &keyType, sizeof(keyType));
+    attrs++;
+    PK11_SETATTRS(attrs, CKA_TOKEN, &ckfalse, sizeof(CK_BBOOL));
+    attrs++;
+    PK11_SETATTRS(attrs, CKA_SENSITIVE, isPrivate ? &cktrue : &ckfalse,
+                  sizeof(CK_BBOOL));
+    attrs++;
+    PK11_SETATTRS(attrs, CKA_PRIVATE, isPrivate ? &cktrue : &ckfalse,
+                  sizeof(CK_BBOOL));
+    attrs++;
+
+    switch (lpk->keyType) {
+        case kyberKey:
+            keyType = CKK_ML_KEM;
+            /* currently we don't deal with seed in nss softoken */
+            if ((lpk->u.kyber.privateValue.len == 0)) {
+                PORT_SetError(SEC_ERROR_BAD_KEY);
+                goto loser;
+            }
+            PK11_SETATTRS(attrs, CKA_DECAPSULATE, &cktrue, sizeof(CK_BBOOL));
+            attrs++;
+            if (nickname) {
+                PK11_SETATTRS(attrs, CKA_LABEL, nickname->data, nickname->len);
+                attrs++;
+            }
+            paramSet = get_MLKEMParamSet(lpk->u.kyber.params);
+            PK11_SETATTRS(attrs, CKA_PARAMETER_SET, (unsigned char *)&paramSet,
+                          sizeof(CK_ML_KEM_PARAMETER_SET_TYPE));
+            attrs++;
+            PK11_SETATTRS(attrs, CKA_VALUE, lpk->u.kyber.privateValue.data,
+                          lpk->u.kyber.privateValue.len);
+            attrs++;
+            break;
+        default:
+            PORT_SetError(SEC_ERROR_BAD_KEY);
+            goto loser;
+    }
+    templateCount = attrs - theTemplate;
+    PORT_Assert(templateCount <= sizeof(theTemplate) / sizeof(CK_ATTRIBUTE));
+
+    genObj = PK11_CreateGenericObject(slot, theTemplate,
+                                      templateCount, PR_FALSE);
+    if (genObj) { rv = SECSuccess; }
+    /* create and return a SECKEYPrivateKey */
+    if (genObj !=NULL && privk != NULL) {
+        objectID = PK11_GetObjectHandle(PK11_TypeGeneric, genObj, NULL);
+        *privk = pk11_MakePrivKey(slot, lpk->keyType, PR_TRUE, objectID, wincx);
+        if (*privk == NULL) {
+            rv = SECFailure;
+        }
+    }
+loser:
+    if (genObj) {
+        PK11_DestroyGenericObject(genObj);
+    }
+    return rv;
+}
+
+
+SECStatus
+pk11_ImportPrivateKeyInfoAndReturnKey(PK11SlotInfo *slot,
+                                      SECKEYPrivateKeyInfo *pki,
+                                      SECItem *nickname,
+                                      PRBool isPrivate, unsigned int keyUsage,
+                                      SECKEYPrivateKey **privk, void *wincx)
+{
+    SECStatus rv = SECFailure;
+    seckeyRawPrivateKey *lpk = NULL;
+    const SEC_ASN1Template *keyTemplate, *paramTemplate;
+    void *paramDest = NULL;
+    PLArenaPool *arena = NULL;
+    SECOidTag algTag;
+    SECOidTag oid_ml_kem_768 = SEC_OID_UNKNOWN;
+    SECOidTag oid_ml_kem_1024 = SEC_OID_UNKNOWN;
+
+    oid_ml_kem_768 = SECOID_AddEntry(&oid_data_ml_kem_768);
+    oid_ml_kem_1024 = SECOID_AddEntry(&oid_data_ml_kem_1024);
+
+    arena = PORT_NewArena(2048);
+    if (!arena) {
+        return SECFailure;
+    }
+
+    /* need to change this to use RSA/DSA keys */
+    lpk = (seckeyRawPrivateKey *)PORT_ArenaZAlloc(arena,
+                                                  sizeof(seckeyRawPrivateKey));
+    if (lpk == NULL) {
+        goto loser;
+    }
+    lpk->arena = arena;
+
+    algTag = SECOID_GetAlgorithmTag(&pki->algorithm);
+    if ((algTag == oid_ml_kem_768) || (algTag == oid_ml_kem_1024)) {
+        if (pki->privateKey.data == NULL || pki->privateKey.len == 0) {
+            PORT_SetError(SEC_ERROR_BAD_KEY);
+            goto loser;
+        }
+        /* choice */
+        switch (pki->privateKey.data[0]) {
+            case SEC_ASN1_CONTEXT_SPECIFIC | 0:
+                keyTemplate = seckey_MLKEMPrivateKeySeedExportTemplate;
+                break;
+            case SEC_ASN1_OCTET_STRING:
+                keyTemplate = seckey_MLKEMPrivateKeyKeyExportTemplate;
+                break;
+            case SEC_ASN1_CONSTRUCTED | SEC_ASN1_SEQUENCE:
+                keyTemplate = seckey_MLKEMPrivateKeyBothExportTemplate;
+                break;
+            default:
+                keyTemplate = NULL;
+                PORT_SetError(SEC_ERROR_BAD_DER);
+                break;
+        }
+        paramTemplate = NULL;
+        paramDest = NULL;
+        lpk->keyType = kyberKey;
+        lpk->u.kyber.params = KyberParamsAlgTag(algTag);
+    }
+
+    if (!keyTemplate) {
+        goto loser;
+    }
+
+    /* decode the private key and any algorithm parameters */
+    rv = SEC_QuickDERDecodeItem(arena, lpk, keyTemplate, &pki->privateKey);
+    if (rv != SECSuccess) {
+        goto loser;
+    }
+
+    if (paramDest && paramTemplate) {
+        rv = SEC_ASN1DecodeItem(arena, paramDest, paramTemplate,
+                                &(pki->algorithm.parameters));
+        if (rv != SECSuccess) {
+            goto loser;
+        }
+    }
+
+    rv = pk11_ImportAndReturnPrivateKey(slot, lpk, nickname, isPrivate,
+                                        keyUsage, privk, wincx);
+loser:
+    if (arena != NULL) {
+        PORT_FreeArena(arena, PR_TRUE);
+    }
+
+    return rv;
+}
+
+SECStatus
+pk11_ImportDERPrivateKeyInfoAndReturnKey(PK11SlotInfo *slot, SECItem *derPKI,
+                                         SECItem *nickname,
+                                         PRBool isPrivate,
+                                         unsigned int keyUsage,
+                                         SECKEYPrivateKey **privk,
+                                         void *wincx)
+{
+    SECKEYPrivateKeyInfo *pki = NULL;
+    PLArenaPool *temparena = NULL;
+    SECStatus rv = SECFailure;
+
+    temparena = PORT_NewArena(DER_DEFAULT_CHUNKSIZE);
+    if (!temparena) {
+        return rv;
+    }
+
+    pki = PORT_ArenaZNew(temparena, SECKEYPrivateKeyInfo);
+    if (!pki) {
+        PORT_FreeArena(temparena, PR_FALSE);
+        return rv;
+    }
+    pki->arena = temparena;
+
+    rv = SEC_ASN1DecodeItem(pki->arena, pki, seckey_PrivateKeyInfoTemplate,
+                            derPKI);
+    if (rv != SECSuccess) {
+        /* If SEC_ASN1DecodeItem fails, we cannot assume anything about the
+         * validity of the data in pki. The best we can do is free the arena
+         * and return. */
+        PORT_FreeArena(temparena, PR_TRUE);
+        return rv;
+    }
+    if (pki->privateKey.data == NULL || pki->privateKey.len == 0) {
+        /* If SEC_ASN1DecodeItems succeeds but SECKEYPrivateKeyInfo.privateKey
+         * is a zero-length octet string, free the arena and return a failure
+         * to avoid trying to zero the corresponding SECItem in
+         * SECKEY_DestroyPrivateKeyInfo(). */
+        PORT_FreeArena(temparena, PR_TRUE);
+        PORT_SetError(SEC_ERROR_BAD_KEY);
+        return SECFailure;
+    }
+
+    rv = pk11_ImportPrivateKeyInfoAndReturnKey(slot, pki, nickname, isPrivate,
+                                               keyUsage, privk, wincx);
+
+    /* this zeroes the key and frees the arena */
+    SECKEY_DestroyPrivateKeyInfo(pki, PR_TRUE /*freeit*/);
+    return rv;
+}
+
+#define PRIV_KEY_LABEL "-----BEGIN PRIVATE KEY-----"
+char *get_DERPKI(FILE *fp)
+{
+    size_t len;
+    size_t start, end;
+    char *buf1, *buf2;
+    size_t i, ret;
+    /* get the full size */
+    fseek(fp, 0L, SEEK_END);
+    len = ftell(fp);
+    buf1 = PORT_Alloc(len+1);
+    if (buf1 == NULL) {
+        return NULL;
+    }
+    rewind(fp);
+    ret = fread(buf1, 1, len, fp);
+    if (ret != len) {
+        PORT_Free(buf1);
+        PORT_SetError(SEC_ERROR_INPUT_LEN);
+        return NULL;
+    }
+    buf1[len] = 0;
+    for(i=0; i < len; i++ ) {
+        if (buf1[i] == '-') {
+            if (PORT_Strncmp(&buf1[i], PRIV_KEY_LABEL,
+                sizeof(PRIV_KEY_LABEL)-1) == 0) {
+                i += sizeof(PRIV_KEY_LABEL)-1;
+               break;
+            }
+        }
+    }
+    if (i >= len) {
+        PORT_Free(buf1);
+        PORT_SetError(SEC_ERROR_INPUT_LEN);
+        return NULL;
+    }
+    start = i;
+    for (;i < len; i++ ) {
+        if (buf1[i] == '-') {
+            break;
+        }
+    }
+    end =  i;
+    len = end - start;
+    buf2 = PORT_Alloc(len);
+    PORT_Memcpy(buf2, &buf1[start], len);
+    buf2[len] = 0;
+    PORT_Free(buf1);
+    return buf2;
+}
+
+/* read a pem file and return a SECKEYPrivateKey */
+SECKEYPrivateKey *
+read_PrivateKey(FILE *fp)
+{
+    SECKEYPrivateKey *privkey = NULL;
+    char *asciiDerPKI = NULL;
+    SECItem derPKI = {siBuffer, NULL, 0};
+    SECItem *item = NULL;
+    PK11SlotInfo *slot = NULL;
+    SECStatus rv;
+
+    slot = PK11_GetInternalSlot();
+    if (slot == NULL) {
+        goto loser;
+    }
+    /* read pem data */
+    asciiDerPKI = get_DERPKI(fp);
+    if (asciiDerPKI == NULL) {
+        goto loser;
+    }
+    item = NSSBase64_DecodeBuffer(NULL, &derPKI, asciiDerPKI,
+                                  PORT_Strlen(asciiDerPKI));
+    if (item == NULL) {
+        goto loser;
+    }
+    rv = pk11_ImportDERPrivateKeyInfoAndReturnKey(slot, &derPKI, NULL,
+                                                  PR_FALSE, KU_ALL,
+                                                  &privkey, NULL);
+    if (rv != SECSuccess) {
+        goto loser;
+    }
+
+    PK11_FreeSlot(slot);
+    PORT_Free(derPKI.data);
+    PORT_Free(asciiDerPKI);
+    return privkey;
+loser:
+    if (slot) {
+        PK11_FreeSlot(slot);
+    }
+    if (derPKI.data) {
+        PORT_Free(derPKI.data);
+    }
+    if (asciiDerPKI) {
+        PORT_Free(asciiDerPKI);
+    }
+    return NULL;
+}

--- a/harness/nss/readpem.h
+++ b/harness/nss/readpem.h
@@ -1,0 +1,5 @@
+/* read a pem file and return a SECKEYPrivateKey */
+#include <stdio.h>
+#include <keythi.h>
+
+SECKEYPrivateKey *read_PrivateKey(FILE *fp);

--- a/harness/nss/time_decapsulate.c
+++ b/harness/nss/time_decapsulate.c
@@ -1,0 +1,281 @@
+#include <memory.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include <prerror.h>
+#include <secerr.h>
+#include <seccomon.h>
+#include <pk11pub.h>
+#include <keyhi.h>
+#include <keythi.h>
+#include <nss.h>
+#include "readpem.h"
+
+void help(char *name) {
+    printf("Usage: %s -i file -o file -k file -n num [-h]\n", name);
+    printf("\n");
+    printf(" -i file    File with concatenated ciphertexts to decrypt\n");
+    printf(" -o file    File where to write the time to decrypt the ciphertext\n");
+    printf(" -k file    File with the RSA private key in PEM format\n");
+    printf(" -n num     Length of individual ciphertexts in bytes\n");
+    printf(" -h         This message\n");
+}
+
+/* Get an architecture specific most precise clock source with the lowest
+ * overhead. Should be executed at the start of the measurement period
+ * (because of barriers against speculative execution
+ */
+uint64_t get_time_before() {
+    uint64_t time_before = 0;
+#if defined( __s390x__ )
+    /* The 64 bit TOD (time-of-day) value is running at 4096.000MHz, but
+     * on some machines not all low bits are updated (the effective frequency
+     * remains though)
+     */
+
+    /* use STCKE as it has lower overhead,
+     * see http://publibz.boulder.ibm.com/epubs/pdf/dz9zr007.pdf
+     */
+    //asm volatile (
+    //    "stck    %0": "=Q" (time_before) :: "memory", "cc");
+
+    uint8_t clk[16];
+    asm volatile (
+          "stcke %0" : "=Q" (clk) :: "memory", "cc");
+    /* since s390x is big-endian we can just do a byte-by-byte copy,
+     * First byte is the epoch number (143 year cycle) while the following
+     * 8 bytes are the same as returned by STCK */
+    time_before = *(uint64_t *)(clk + 1);
+#elif defined( __PPC64__ )
+    asm volatile (
+        "mftb    %0": "=r" (time_before) :: "memory", "cc");
+#elif defined( __aarch64__ )
+    asm volatile (
+        "mrs %0, cntvct_el0": "=r" (time_before) :: "memory", "cc");
+#elif defined( __x86_64__ )
+    uint32_t time_before_high = 0, time_before_low = 0;
+    asm volatile (
+        "CPUID\n\t"
+        "RDTSC\n\t"
+        "mov %%edx, %0\n\t"
+        "mov %%eax, %1\n\t" : "=r" (time_before_high),
+        "=r" (time_before_low)::
+        "%rax", "%rbx", "%rcx", "%rdx");
+    time_before = (uint64_t)time_before_high<<32 | time_before_low;
+#else
+#error Unsupported architecture
+#endif /* ifdef __s390x__ */
+    return time_before;
+}
+
+/* Get an architecture specific most precise clock source with the lowest
+ * overhead. Should be executed at the end of the measurement period
+ * (because of barriers against speculative execution
+ */
+uint64_t get_time_after() {
+    uint64_t time_after = 0;
+#if defined( __s390x__ )
+    /* The 64 bit TOD (time-of-day) value is running at 4096.000MHz, but
+     * on some machines not all low bits are updated (the effective frequency
+     * remains though)
+     */
+
+    /* use STCKE as it has lower overhead,
+     * see http://publibz.boulder.ibm.com/epubs/pdf/dz9zr007.pdf
+     */
+    //asm volatile (
+    //    "stck    %0": "=Q" (time_before) :: "memory", "cc");
+
+    uint8_t clk[16];
+    asm volatile (
+          "stcke %0" : "=Q" (clk) :: "memory", "cc");
+    /* since s390x is big-endian we can just do a byte-by-byte copy,
+     * First byte is the epoch number (143 year cycle) while the following
+     * 8 bytes are the same as returned by STCK */
+    time_after = *(uint64_t *)(clk + 1);
+#elif defined( __PPC64__ )
+    /* Note: mftb can be used with a single instruction on ppc64, for ppc32
+     * it's necessary to read upper and lower 32bits of the values in two
+     * separate calls and verify that we didn't do that during low value
+     * overflow
+     */
+    asm volatile (
+        "mftb    %0": "=r" (time_after) :: "memory", "cc");
+#elif defined( __aarch64__ )
+    asm volatile (
+        "mrs %0, cntvct_el0": "=r" (time_after) :: "memory", "cc");
+#elif defined( __x86_64__ )
+    uint32_t time_after_high = 0, time_after_low = 0;
+    asm volatile (
+        "RDTSCP\n\t"
+        "mov %%edx, %0\n\t"
+        "mov %%eax, %1\n\t"
+        "CPUID\n\t": "=r" (time_after_high),
+        "=r" (time_after_low)::
+        "%rax", "%rbx", "%rcx", "%rdx");
+    time_after = (uint64_t)time_after_high<<32 | time_after_low;
+#else
+#error Unsupported architecture
+#endif /* ifdef __s390x__ */
+    return time_after;
+}
+
+int main(int argc, char *argv[]) {
+    int result = 1, r_ret;
+    size_t ciphertext_len = 0;
+    FILE *fp;
+    char *key_file_name = NULL, *in_file_name = NULL, *out_file_name = NULL;
+    int in_fd = -1, out_fd = -1;
+    SECItem ciphertext = { siBuffer, NULL, 0 };
+    SECKEYPrivateKey *pkey = NULL;
+    PK11SymKey *outkey = NULL;
+    SECStatus rv;
+    int opt;
+    int nsserr = 0;
+    uint64_t time_before, time_after, time_diff;
+
+    while ((opt = getopt(argc, argv, "i:o:k:n:h")) != -1 ) {
+        switch (opt) {
+            case 'i':
+                in_file_name = optarg;
+                break;
+            case 'o':
+                out_file_name = optarg;
+                break;
+            case 'k':
+                key_file_name = optarg;
+                break;
+            case 'n':
+                sscanf(optarg, "%zi", &ciphertext_len);
+                break;
+            case 'h':
+                help(argv[0]);
+                exit(0);
+                break;
+            default:
+                fprintf(stderr, "Unknown option: %c\n", opt);
+                help(argv[0]);
+                exit(1);
+                break;
+        }
+    }
+
+    if (!in_file_name || !out_file_name || !key_file_name || !ciphertext_len) {
+        fprintf(stderr, "Missing parameters!\n");
+        help(argv[0]);
+        exit(1);
+    }
+    PORT_SetError(0);
+
+    in_fd = open(in_file_name, O_RDONLY);
+    if (in_fd == -1) {
+        fprintf(stderr, "can't open input file %s\n", in_file_name);
+        goto err;
+    }
+
+    out_fd = open(out_file_name, O_WRONLY|O_TRUNC|O_CREAT, 0666);
+    if (out_fd == -1) {
+        fprintf(stderr, "can't open output file %s\n", out_file_name);
+        goto err;
+    }
+
+
+    fprintf(stderr, "malloc(ciphertext)\n");
+    ciphertext.data = malloc(ciphertext_len);
+    if (!ciphertext.data)
+        goto err;
+
+    ciphertext.len = ciphertext_len;
+
+    /* init NSS */
+    fprintf(stderr, "Initialize NSS\n");
+    rv = NSS_NoDB_Init(NULL);
+    if (rv != SECSuccess) {
+        goto err;
+    }
+
+    fprintf(stderr, "fopen()\n");
+    fp = fopen(key_file_name, "r");
+    if (!fp) {
+        fprintf(stderr, "Can't open key file %s\n", key_file_name);
+        goto err;
+    }
+
+    fprintf(stderr, "read_PrivateKey()\n");
+
+    if ((pkey = read_PrivateKey(fp)) == NULL)
+        goto err;
+
+    fprintf(stderr, "fclose()\n");
+    if (fclose(fp) != 0)
+        goto err;
+
+    fprintf(stderr, "Decrypting ciphertexts...\n");
+
+    while ((r_ret = read(in_fd, ciphertext.data, ciphertext.len)) > 0) {
+        if (r_ret != ciphertext.len) {
+            fprintf(stderr, "read less data than expected (truncated file?)\n");
+            goto err;
+        }
+
+        time_before = get_time_before();
+
+        rv= PK11_Decapsulate(pkey, &ciphertext, CKM_HKDF_DERIVE,
+                PK11_ATTR_SESSION | PK11_ATTR_INSENSITIVE, CKF_DERIVE,
+                &outkey);
+
+        time_after = get_time_after();
+
+        if (rv != SECSuccess) {
+            fprintf(stderr, "Decapsulation failure\n");
+            fprintf(stderr, "%x\n", ciphertext.data[0]);
+            goto err;
+        }
+
+        if ( PK11_GetKeyLength(outkey) != 32) {
+            fprintf(stderr, "Unexpected plaintext length: %lu\n",
+                    PK11_GetKeyLength(outkey));
+            PK11_FreeSymKey(outkey);
+            goto err;
+        }
+        PK11_FreeSymKey(outkey);
+
+        time_diff = time_after - time_before;
+
+        r_ret = write(out_fd, &time_diff, sizeof(time_diff));
+        if (r_ret <= 0) {
+            fprintf(stderr, "Write error\n");
+            goto err;
+        }
+    }
+
+    result = 0;
+    fprintf(stderr, "finished\n");
+    goto out;
+
+    err:
+    fprintf(stderr, "failed!\n");
+    nsserr= PORT_GetError();
+    if (nsserr != 0) {
+        fprintf(stderr, "%s: %s (%d)\n", PR_ErrorToName(nsserr),
+                PORT_ErrorToString(nsserr), nsserr);
+    } else {
+        perror("clib fail");
+    }
+    result = 1;
+
+    out:
+    if (ciphertext.data)
+        free(ciphertext.data);
+    if (pkey)
+        SECKEY_DestroyPrivateKey(pkey);
+    if (in_fd >= 0)
+        close(in_fd);
+    if (out_fd >= 0)
+        close(out_fd);
+    return result;
+}
+


### PR DESCRIPTION
NSS does not yet support importing ml-kem keys from pkcs #5 encodeded keys, so readpme.c fixes that deficiency by hand copying NSS raw key parsing files from NSS and modifying them to support ml-kem. In all other ways it functions just like the openssl time_decapsulate function, since it reads the key in from a pem file, it uses NO_DB_INIT.